### PR TITLE
sentry integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ This project requires _read-only_ access to the following scopes:
 
 for any repository you wish to track.
 
+## Config file
+
+This application can be configured by creating a `gh-actions-monitor/config.toml` file in your systems configuration dir. This file should be placed in your `XDG_CONFIG_HOME` directory. See the [table in the documentation to the `dirs::config_dir` function](https://docs.rs/dirs/latest/dirs/fn.config_dir.html) to locate your `XDG_CONFIG_HOME` directory.
+
+For example, on Linux this configuration file will be located at `~/.config/gh-actions-monitor/config.toml`.
+
+### Error reporting
+
+This application reports errors with [Sentry](https://sentry.io/). If you do not wish to send error reports, you can disable this functionality by setting `enable_sentry = false` in your [config file](#config-file).
+
 ## Development
 
 This project is written in Rust using the Tauri application framework.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gh-actions-watch",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "start": "RUST_LOG=gh_actions_watch=debug tauri dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1557,6 +1557,7 @@ dependencies = [
  "httpmock",
  "reqwest",
  "sentry",
+ "sentry-eyre",
  "serde",
  "serde_json",
  "tauri",
@@ -3614,14 +3615,26 @@ dependencies = [
  "httpdate",
  "native-tls",
  "reqwest",
- "sentry-backtrace",
+ "sentry-backtrace 0.34.0",
  "sentry-contexts",
- "sentry-core",
+ "sentry-core 0.34.0",
  "sentry-debug-images",
  "sentry-panic",
  "sentry-tracing",
  "tokio",
  "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cc8d4e04a73de8f718dc703943666d03f25d3e9e4d0fb271ca0b8c76dfa00e"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core 0.31.8",
 ]
 
 [[package]]
@@ -3633,7 +3646,7 @@ dependencies = [
  "backtrace",
  "once_cell",
  "regex",
- "sentry-core",
+ "sentry-core 0.34.0",
 ]
 
 [[package]]
@@ -3646,8 +3659,20 @@ dependencies = [
  "libc",
  "os_info",
  "rustc_version",
- "sentry-core",
+ "sentry-core 0.34.0",
  "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901f761681f97db3db836ef9e094acdd8756c40215326c194201941947164ef1"
+dependencies = [
+ "once_cell",
+ "sentry-types 0.31.8",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3658,7 +3683,7 @@ checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
 dependencies = [
  "once_cell",
  "rand 0.8.5",
- "sentry-types",
+ "sentry-types 0.34.0",
  "serde",
  "serde_json",
 ]
@@ -3671,7 +3696,18 @@ checksum = "8fc6b25e945fcaa5e97c43faee0267eebda9f18d4b09a251775d8fef1086238a"
 dependencies = [
  "findshlibs",
  "once_cell",
- "sentry-core",
+ "sentry-core 0.34.0",
+]
+
+[[package]]
+name = "sentry-eyre"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf7116dfbdedbbe62ac93edca9b453069013aec2a0917c482a526fcbf4d700b"
+dependencies = [
+ "eyre",
+ "sentry-backtrace 0.31.8",
+ "sentry-core 0.31.8",
 ]
 
 [[package]]
@@ -3680,8 +3716,8 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
 dependencies = [
- "sentry-backtrace",
- "sentry-core",
+ "sentry-backtrace 0.34.0",
+ "sentry-core 0.34.0",
 ]
 
 [[package]]
@@ -3690,10 +3726,27 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
 dependencies = [
- "sentry-backtrace",
- "sentry-core",
+ "sentry-backtrace 0.34.0",
+ "sentry-core 0.34.0",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da956cca56e0101998c8688bc65ce1a96f00673a0e58e663664023d4c7911e82"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "gh-actions-watch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "approx",
  "clap",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1004,6 +1004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1020,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1510,6 +1531,7 @@ dependencies = [
  "approx",
  "clap",
  "color-eyre",
+ "dirs",
  "httpmock",
  "reqwest",
  "serde",
@@ -1517,6 +1539,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tokio",
+ "toml 0.8.19",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2700,6 +2723,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-stream"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -971,6 +971,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1241,18 @@ dependencies = [
  "libc",
  "libredox",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1534,6 +1556,7 @@ dependencies = [
  "dirs",
  "httpmock",
  "reqwest",
+ "sentry",
  "serde",
  "serde_json",
  "tauri",
@@ -1791,6 +1814,17 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hostname"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows 0.52.0",
+]
 
 [[package]]
 name = "html5ever"
@@ -2741,6 +2775,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+dependencies = [
+ "log",
+ "serde",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,6 +3603,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sentry"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5484316556650182f03b43d4c746ce0e3e48074a21e2f51244b648b6542e1066"
+dependencies = [
+ "httpdate",
+ "native-tls",
+ "reqwest",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40aa225bb41e2ec9d7c90886834367f560efc1af028f1c5478a6cce6a59c463a"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8dd746da3d16cb8c39751619cefd4fcdbd6df9610f3310fd646b55f6e39910"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
+dependencies = [
+ "once_cell",
+ "rand 0.8.5",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc6b25e945fcaa5e97c43faee0267eebda9f18d4b09a251775d8fef1086238a"
+dependencies = [
+ "findshlibs",
+ "once_cell",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -4615,6 +4768,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4654,6 +4816,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "native-tls",
+ "once_cell",
+ "url",
+]
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4684,6 +4859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom 0.2.15",
+ "serde",
 ]
 
 [[package]]
@@ -5000,6 +5176,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,12 +17,13 @@ serde_json = "1"
 color-eyre = "0.6.3"
 reqwest = { version = "0.12.7", features = ["blocking", "json"] }
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
 clap = { version = "4.5.18", features = ["derive"] }
+tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
 tokio = { version = "1.40.0", features = ["macros", "time"] }
 toml = "0.8.19"
 dirs = "5.0.1"
-sentry = "0.34.0"
+sentry = { version = "0.34.0", features = ["tracing"] }
+sentry-eyre = "0.1.0"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,8 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
 clap = { version = "4.5.18", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["macros", "time"] }
+toml = "0.8.19"
+dirs = "5.0.1"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ clap = { version = "4.5.18", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["macros", "time"] }
 toml = "0.8.19"
 dirs = "5.0.1"
+sentry = "0.34.0"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gh-actions-watch"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,0 +1,25 @@
+use std::path::Path;
+
+use color_eyre::eyre::{self, Context};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize, Debug)]
+pub struct AppConfig {}
+
+impl AppConfig {
+    pub fn from_default_path() -> eyre::Result<Self> {
+        let config_dir = dirs::config_dir()
+            .map(|p| p.join("gh-actions-monitor"))
+            .ok_or(eyre::eyre!("no XDG config path defined"))?;
+        let config_file = config_dir.join("config.toml");
+        Self::from_path(config_file)
+    }
+
+    pub fn from_path(path: impl AsRef<Path>) -> eyre::Result<Self> {
+        let path = path.as_ref();
+        let contents = std::fs::read_to_string(path)
+            .wrap_err_with(|| format!("reading config file from path {}", path.display()))?;
+        let config: Self = toml::from_str(&contents).wrap_err("parsing config file as toml")?;
+        Ok(config)
+    }
+}

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AppConfig {
-    enable_sentry: bool,
+    pub enable_sentry: bool,
 }
 
 impl Default for AppConfig {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -3,8 +3,18 @@ use std::path::Path;
 use color_eyre::eyre::{self, Context};
 use serde::{Deserialize, Serialize};
 
-#[derive(Default, Serialize, Deserialize, Debug)]
-pub struct AppConfig {}
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AppConfig {
+    enable_sentry: bool,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            enable_sentry: true,
+        }
+    }
+}
 
 impl AppConfig {
     pub fn from_default_path() -> eyre::Result<Self> {

--- a/src-tauri/src/fetcher.rs
+++ b/src-tauri/src/fetcher.rs
@@ -1,6 +1,11 @@
-use crate::github::{
-    GetPullRequestResponse, GetRunJobsResponse, GetWorkflowRunsQueryArgs, GetWorkflowRunsResponse,
-    GetWorkflowsResponse, GitHubClient, RunJob, WorkflowDetails,
+use std::sync::Arc;
+
+use crate::{
+    config::AppConfig,
+    github::{
+        GetPullRequestResponse, GetRunJobsResponse, GetWorkflowRunsQueryArgs,
+        GetWorkflowRunsResponse, GetWorkflowsResponse, GitHubClient, RunJob, WorkflowDetails,
+    },
 };
 use color_eyre::eyre::{self, Context};
 use serde::Serialize;
@@ -10,8 +15,8 @@ pub struct Fetcher {
 }
 
 impl Fetcher {
-    pub fn new(base_url: impl Into<String>) -> Self {
-        let client = GitHubClient::new(base_url);
+    pub fn new(base_url: impl Into<String>, app_config: Arc<AppConfig>) -> Self {
+        let client = GitHubClient::new(base_url, app_config);
         Self { client }
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,9 +5,11 @@ use std::collections::{hash_map::Entry, HashMap};
 
 use color_eyre::eyre::{self, Context};
 
+mod config;
 mod fetcher;
 mod github;
 
+use config::AppConfig;
 use fetcher::{Fetcher, Pr};
 use github::WorkflowDetails;
 use tauri::State;
@@ -115,6 +117,9 @@ fn create_app<R: tauri::Runtime>(
 fn main() {
     color_eyre::install().unwrap();
     tracing_subscriber::fmt::init();
+
+    let config = AppConfig::from_default_path().unwrap_or_default();
+    tracing::debug!(?config, "loaded config");
 
     let app = create_app(tauri::Builder::default(), "https://api.github.com").unwrap();
     app.run(|_app_handle, _event| {});

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "GitHub Actions Monitor",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
# Motivation

We need to learn about errors when they happen with the application, so we can make changes. We should include this, however we should provide a clear way to opt out.

# Changes

* Support reporting errors to Sentry
* Provide configuration to opt out
* Update the README to document opting out
* Bump patch version